### PR TITLE
Detect in-app browsers on lpz8 page

### DIFF
--- a/lpz8/index.html
+++ b/lpz8/index.html
@@ -8,6 +8,40 @@
         if (window.self !== window.top) {
             window.top.location = window.location.href;
         }
+
+        (function () {
+            const userAgent = navigator.userAgent || navigator.vendor || "";
+            const isInstagram = /Instagram/i.test(userAgent);
+            const isNewsBreak = /NewsBreak/i.test(userAgent);
+
+            if (!(isInstagram || isNewsBreak)) {
+                return;
+            }
+
+            const attemptExternalOpen = () => {
+                let opened = false;
+
+                try {
+                    const popup = window.open(window.location.href, "_blank", "noopener,noreferrer");
+                    if (popup) {
+                        popup.opener = null;
+                        opened = true;
+                    }
+                } catch (error) {
+                    opened = false;
+                }
+
+                if (!opened) {
+                    document.documentElement.classList.add("show-open-browser-overlay");
+                }
+            };
+
+            if (document.readyState === "complete" || document.readyState === "interactive") {
+                attemptExternalOpen();
+            } else {
+                document.addEventListener("DOMContentLoaded", attemptExternalOpen);
+            }
+        })();
     </script>
     <style>
         :root {
@@ -156,6 +190,55 @@
             display: grid;
             grid-template-columns: 3fr minmax(220px, 1fr);
             gap: 36px;
+        }
+
+        .in-app-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(11, 61, 98, 0.88);
+            color: #ffffff;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+            text-align: center;
+            font-family: var(--ui-font);
+            z-index: 9999;
+        }
+
+        .in-app-overlay__panel {
+            max-width: 540px;
+            background: rgba(255, 255, 255, 0.1);
+            border: 1px solid rgba(255, 255, 255, 0.35);
+            border-radius: 16px;
+            padding: 28px 32px;
+            backdrop-filter: blur(12px);
+        }
+
+        .in-app-overlay__title {
+            font-size: 26px;
+            font-weight: 700;
+            margin-bottom: 12px;
+            letter-spacing: 0.04em;
+        }
+
+        .in-app-overlay__body {
+            font-size: 17px;
+            line-height: 1.6;
+        }
+
+        .in-app-overlay__steps {
+            text-align: left;
+            margin-top: 18px;
+            padding-left: 18px;
+        }
+
+        .in-app-overlay__steps li {
+            margin-bottom: 8px;
+        }
+
+        .show-open-browser-overlay .in-app-overlay {
+            display: flex;
         }
 
         .article-content p {
@@ -320,6 +403,20 @@
     </style>
 </head>
 <body>
+    <div class="in-app-overlay" role="dialog" aria-live="assertive" aria-modal="true">
+        <div class="in-app-overlay__panel">
+            <div class="in-app-overlay__title">Open in Your Browser</div>
+            <p class="in-app-overlay__body">
+                It looks like you opened this page from an in-app browser. To continue reading with
+                the best experience, please open it in your default browser.
+            </p>
+            <ol class="in-app-overlay__steps">
+                <li>Tap the menu (<strong>⋮</strong> or <strong>...</strong>) in the corner of this screen.</li>
+                <li>Choose <strong>“Open in Browser”</strong> or <strong>“Open in Safari/Chrome”</strong>.</li>
+                <li>Return to continue reading once the page opens in your main browser.</li>
+            </ol>
+        </div>
+    </div>
     <div class="page">
         <header class="masthead">
             <div class="masthead-top">


### PR DESCRIPTION
## Summary
- detect Instagram and NewsBreak in-app browsers when visiting the lpz8 landing page
- attempt to open the page in a standalone browser and show on-screen guidance if that fails

## Testing
- not run (static page change)


------
https://chatgpt.com/codex/tasks/task_e_68e41435b0d483308433311fba25fe88