### PR TITLE
Reorder LP tracking scripts on lpz8

### DIFF
--- a/lpz8/index.html
+++ b/lpz8/index.html
@@ -400,6 +400,49 @@
         </footer>
     </div>
 
+    <!-- ✅ RedTrack LP Clicks Tracking Script -->
+    <script>
+    (function() {
+      var domain = "track.nutr.site";
+      var type = "LP Clicks";
+
+      function getCookie(name) {
+        var value = "; " + document.cookie;
+        var parts = value.split("; " + name + "=");
+        if (parts.length == 2) return parts.pop().split(";").shift();
+      }
+
+      function getSessionClickID() {
+        return sessionStorage.getItem('rtkclickid');
+      }
+
+      function fireLpClick() {
+        var rtCookie = getCookie('rtkclickid-store') || getSessionClickID();
+        if (!rtCookie) return;
+
+        var url = "https://" + domain + "/postback?clickid=" + rtCookie + "&type=" + encodeURIComponent(type);
+
+        // Prevent double-firing on rapid clicks
+        if (window.__lpClickFired && (Date.now() - window.__lpClickFired) < 1000) return;
+        window.__lpClickFired = Date.now();
+
+        try {
+          if (navigator.sendBeacon) {
+            navigator.sendBeacon(url);
+          } else {
+            (new Image()).src = url + "&_ts=" + Date.now();
+          }
+        } catch (e) {
+          console.warn("LP Click tracking failed:", e);
+        }
+      }
+
+      // Attach to all CTAs with .cta-button class
+      document.querySelectorAll('.cta-button').forEach(function(el) {
+        el.addEventListener('click', fireLpClick, { passive: true });
+      });
+    })();
+    </script>
     <script src="https://track.nutr.site/unilpclick.js?attribution=lastpaid&cookiedomain=&cookieduration=90&defaultcampaignid=&regviewonce=false"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move the inline RedTrack LP click tracking snippet above the external unilpclick loader on lpz8 to ensure it binds before the script executes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e63b7c01e0833093bc220783dff33b